### PR TITLE
Added real removing session from redis

### DIFF
--- a/lib/redis.js
+++ b/lib/redis.js
@@ -7,5 +7,6 @@ module.exports = (settings) => {
   return {
     get: util.promisify(client.get).bind(client),
     set: util.promisify(client.set).bind(client),
+    del: util.promisify(client.del).bind(client),
   }
 }

--- a/lib/session.js
+++ b/lib/session.js
@@ -21,10 +21,17 @@ class Session {
 
       Object.defineProperty(ctx, this.key, {
         get: () => session,
-        set: value => (session = value),
+        set: (value) => {
+          session = value === null ? {} : value
+        },
       })
 
       await next()
+      if (Object.keys(session || {}).length === 0) {
+        await this.redis.del(key)
+        return
+      }
+
       await this.redis.set(key, JSON.stringify(session))
     }
   }

--- a/lib/session.js
+++ b/lib/session.js
@@ -27,12 +27,12 @@ class Session {
       })
 
       await next()
-      if (Object.keys(session || {}).length === 0) {
+      
+      if (!Object.keys(session || {}).length) {
         await this.redis.del(key)
-        return
+      } else {
+        await this.redis.set(key, JSON.stringify(session))
       }
-
-      await this.redis.set(key, JSON.stringify(session))
     }
   }
 }

--- a/test/session.test.js
+++ b/test/session.test.js
@@ -14,6 +14,8 @@ describe('session', () => {
     const callback = sinon.fake()
 
     bot.command('/set', (ctx) => {
+      expect(ctx.session).to.deep.equal({})
+
       ctx.session.user = user
 
       callback()
@@ -31,6 +33,7 @@ describe('session', () => {
     bot.command('/get', (ctx) => {
       callback()
       expect(ctx.session.user).to.deep.equal(user)
+      ctx.session = null
     })
 
     await handleUpdate('/get')

--- a/test/session.test.js
+++ b/test/session.test.js
@@ -33,7 +33,6 @@ describe('session', () => {
     bot.command('/get', (ctx) => {
       callback()
       expect(ctx.session.user).to.deep.equal(user)
-      ctx.session = null
     })
 
     await handleUpdate('/get')


### PR DESCRIPTION
This improvement real removes key from redis If session is `empty object` or after setting `null` for session.

Bump version at **npm**, please :pray: 